### PR TITLE
fix(ci): update Go versions in Docker and workflows to match go.mod

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
       
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version-file: 'go.mod'
       
       - name: Get version information
         id: get_version

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version-file: 'go.mod'
       - name: Check formatting
         id: check-format
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY web/ ./
 RUN npm run build
 
 # Stage 2: Build Go backend
-FROM golang:1.25-alpine AS backend-build
+FROM golang:1.26-alpine AS backend-build
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
Resolves the Docker image build failure in CI by updating the backend builder image to `golang:1.26-alpine` to match `go.mod`. Also configures `setup-go` to dynamically read Go versions from `go.mod` in the build and format workflows.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/Gemini_3.5_Flash-4285F4?logo=googlegemini&logoColor=white)
